### PR TITLE
Refine and clarify, then share :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ config.json
 */*/._*
 coverage.*
 .settings
-test/fixtures/awesomeLog
+test/fixtures/awesomeLog.json
+log

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,6 @@ exports.tls = {
 };
 
 exports.crumbOptions = {
-  restful: true,
-  cookieOptions: { isSecure: true }
+    restful: true,
+    cookieOptions: { isSecure: true }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,3 +23,8 @@ exports.tls = {
 
     ca: []
 };
+
+exports.crumbOptions = {
+  restful: true,
+  cookieOptions: { isSecure: true }
+};

--- a/lib/crumbit.js
+++ b/lib/crumbit.js
@@ -25,12 +25,7 @@ exports.register = (server, options, next) =>  {
     //    * headers.cookie: 'sid-example=sessionCookieValue'
     // See ./test/api/user.js for examples of how to build test requests with headers configured properly.
 
-    const configs = {
-        restful: true,
-        cookieOptions: { isSecure: true }
-    };
-
-    server.register({ register: require('crumb'), options: configs }, (err) => {
+    server.register({ register: require('crumb'), options }, (err) => {
 
         if (err) {
             return next(err);

--- a/lib/good.js
+++ b/lib/good.js
@@ -1,12 +1,17 @@
 'use strict';
 
+// Load modules
+
+const Good = require('good');
+
 // Declare internals
 
 const internals = {};
 
 exports.register = (server, options, next) =>  {
+    exports.options = options; // TODO: find where export is used
 
-    server.register({ register: require('good'), options: internals.options }, (err) => {
+    server.register({ register: Good, options }, (err) => {
 
         if (err) {
             return next(err);
@@ -19,42 +24,3 @@ exports.register = (server, options, next) =>  {
 exports.register.attributes = {
     name: 'Good'
 };
-
-exports.options = internals.options = {
-    ops: { interval: 1000 },
-    reporters: {
-        myConsoleReporter: [{
-            module: 'good-squeeze',
-            name: 'Squeeze',
-            args: [{ log: '*', response: '*' }]
-        }, {
-            module: 'good-console'
-        }, 'stdout'],
-        myFileReporter: [{
-            module: 'good-squeeze',
-            name: 'Squeeze',
-            args: [{ ops: '*' }]
-        }, {
-            module: 'good-squeeze',
-            name: 'SafeJson'
-        }, {
-            module: 'good-file',
-            args: ['./test/fixtures/awesomeLog']
-        }]
-    }
-};
-
-// exports.options = internals.options = {
-//     opsInterval: 1000,
-//     filter:{
-//         access_token: 'censor'
-//     },
-//     reporters: [{
-//         reporter: require('good-console'),
-//         events: { log: '*', response: '*' }
-//     }, {
-//         reporter: require('good-file'),
-//         events: { ops: '*' },
-//         config: './test/fixtures/awesomeLog'
-//     }]
-// };

--- a/lib/good.js
+++ b/lib/good.js
@@ -9,6 +9,7 @@ const Good = require('good');
 const internals = {};
 
 exports.register = (server, options, next) =>  {
+
     exports.options = options; // TODO: find where export is used
 
     server.register({ register: Good, options }, (err) => {

--- a/lib/home.js
+++ b/lib/home.js
@@ -2,15 +2,9 @@
 
 // Load modules
 
-const Path = require('path');
-
-
 // Declare internals
 
-const internals = {
-    rootPath: Path.resolve(__dirname, '../'),
-    viewsPath: Path.resolve(__dirname, '../views')
-};
+const internals = {};
 
 exports.register = (server, options, next) => {
 
@@ -36,9 +30,9 @@ internals.after = (server, next) => {
         engines: {
             html: require('handlebars')
         },
-        path: '../views',
-        partialsPath: '../views/partials',
-        relativeTo: __dirname
+        path: 'views',
+        partialsPath: 'views/partials',
+        relativeTo: process.cwd() // prefer this over __dirname when compiling to dist/cjs and using rollup
     });
 
     // Routing for static files
@@ -189,4 +183,8 @@ internals.after = (server, next) => {
     ]);
 
     return next();
+};
+
+exports.register.attributes = {
+    name: 'Home'
 };

--- a/lib/lout.js
+++ b/lib/lout.js
@@ -14,7 +14,8 @@ exports.register = (server, options, next) => {
     // Earlier versions of hapi included vision and inert out of hapi. Now,
     // these must be included seperately.
 
-    server.register({ register: Lout, options }, err => {
+    server.register({ register: Lout, options }, (err) => {
+
         if (err) {
             return next(err);
         }

--- a/lib/lout.js
+++ b/lib/lout.js
@@ -14,18 +14,9 @@ exports.register = (server, options, next) => {
     // Earlier versions of hapi included vision and inert out of hapi. Now,
     // these must be included seperately.
 
-    server.dependency(['inert', 'vision'], internals.after(server, next));
-
-    // return next();
-};
-
-
-internals.after = (server, next) => {
-
-    server.register(Lout, (err) => {
-
-        if (!err){
-            return next();
+    server.register({ register: Lout, options }, err => {
+        if (err) {
+            return next(err);
         }
 
         return next();
@@ -33,5 +24,8 @@ internals.after = (server, next) => {
 };
 
 exports.register.attributes = {
-    name: 'Lout'
+    name: 'Lout',
+    dependencies: ['inert', 'vision']
 };
+
+

--- a/lib/start.js
+++ b/lib/start.js
@@ -11,6 +11,12 @@ const Config = require('./config');
 
 const internals = {};
 
+internals.goodFilePath = (() => {
+    const env = process.env.NODE_ENV;
+    const name = env ? 'good '+env+'.log' : 'good.log';
+    return './log/'+name;
+})();
+
 internals.manifest = {
     connections: [
         {
@@ -60,8 +66,14 @@ internals.manifest = {
             }
         },
         {
-            plugin: './crumbit',
-            options: {
+            plugin: {
+                register: './crumbit',
+                options: { // pluginOptions - passed as 'options' to plugin
+                    restful: true,
+                    cookieOptions: { isSecure: true }
+                },
+            },
+            options: { // registerOptions - NOT passed to plugin; instead passed to Glue under the hood
                 select: ['web-tls']
             }
         },
@@ -78,7 +90,33 @@ internals.manifest = {
             plugin: 'inert'
         },
         {
-            plugin: './good'
+            plugin: {
+                register: './good',
+                options: {
+                    ops: { interval: 1000 },
+                    reporters: {
+                        myConsoleReporter: [{
+                            module: 'good-squeeze',
+                            name: 'Squeeze',
+                            args: [{ log: '*', response: '*' }]
+                        }, {
+                            module: 'good-console'
+                        }, 'stdout'],
+                        myFileReporter: [{
+                            module: 'good-squeeze',
+                            name: 'Squeeze',
+                            args: [{ ops: '*' }]
+                        }, {
+                            module: 'good-squeeze',
+                            name: 'SafeJson'
+                        }, {
+                            module: 'good-file',
+                            args: [internals.goodFilePath]
+                        }]
+                    }
+
+                }
+            }
         },
         {
             plugin: './lout',
@@ -90,7 +128,7 @@ internals.manifest = {
 };
 
 internals.composeOptions = {
-    relativeTo: __dirname
+    relativeTo: __dirname // NOTE: use `Path.resolve(process.cwd() 'lib')` when using babel/typescript/rollup
 };
 
 Server.init(internals.manifest, internals.composeOptions, (err, server) => {
@@ -100,6 +138,6 @@ Server.init(internals.manifest, internals.composeOptions, (err, server) => {
     const web = server.select('web');
     const webTls = server.select('web-tls');
 
-    console.log('Web server started at: ' + web.info.uri);
-    console.log('WebTLS server started at: ' + webTls.info.uri);
+    server.log('Web server started at: ' + web.info.uri);
+    server.log('WebTLS server started at: ' + webTls.info.uri);
 });

--- a/lib/start.js
+++ b/lib/start.js
@@ -12,9 +12,10 @@ const Config = require('./config');
 const internals = {};
 
 internals.goodFilePath = (() => {
+
     const env = process.env.NODE_ENV;
-    const name = env ? 'good '+env+'.log' : 'good.log';
-    return './log/'+name;
+    const name = env ? 'good ' + env + '.log' : 'good.log';
+    return './log/' + name;
 })();
 
 internals.manifest = {
@@ -71,7 +72,7 @@ internals.manifest = {
                 options: { // pluginOptions - passed as 'options' to plugin
                     restful: true,
                     cookieOptions: { isSecure: true }
-                },
+                }
             },
             options: { // registerOptions - NOT passed to plugin; instead passed to Glue under the hood
                 select: ['web-tls']

--- a/test/api/user.js
+++ b/test/api/user.js
@@ -345,7 +345,7 @@ internals.manifest = {
         {
             plugin: {
                 register: './crumbit',
-                options: Config.crumbOptions,
+                options: Config.crumbOptions
             },
             options: {
                 select: ['web-tls']

--- a/test/api/user.js
+++ b/test/api/user.js
@@ -343,7 +343,10 @@ internals.manifest = {
             plugin: 'hapi-auth-cookie'
         },
         {
-            plugin: './crumbit',
+            plugin: {
+                register: './crumbit',
+                options: Config.crumbOptions,
+            },
             options: {
                 select: ['web-tls']
             }

--- a/test/auth-cookie.js
+++ b/test/auth-cookie.js
@@ -211,7 +211,10 @@ internals.manifest = {
             plugin: 'hapi-auth-cookie'
         },
         {
-            plugin: './crumbit',
+            plugin: {
+                register: './crumbit',
+                options: Config.crumbOptions,
+            },
             options: {
                 select: ['web-tls']
             }

--- a/test/auth-cookie.js
+++ b/test/auth-cookie.js
@@ -126,7 +126,7 @@ describe('/auth-cookie', () => {
                         expect(res.statusCode).to.equal(302);
                         callback();
                     });
-                }], (err, results) => {
+                }], (err/*, results*/) => {
 
                     Auth.options = internals.original;
                     expect(err).to.not.exist();
@@ -213,7 +213,7 @@ internals.manifest = {
         {
             plugin: {
                 register: './crumbit',
-                options: Config.crumbOptions,
+                options: Config.crumbOptions
             },
             options: {
                 select: ['web-tls']

--- a/test/crumbit.js
+++ b/test/crumbit.js
@@ -98,7 +98,10 @@ internals.manifest = {
             plugin: 'hapi-auth-cookie'
         },
         {
-            plugin: './crumbit',
+            plugin: {
+                register: './crumbit',
+                options: Config.crumbOptions,
+            },
             options: {
                 select: ['web-tls']
             }

--- a/test/crumbit.js
+++ b/test/crumbit.js
@@ -100,7 +100,7 @@ internals.manifest = {
         {
             plugin: {
                 register: './crumbit',
-                options: Config.crumbOptions,
+                options: Config.crumbOptions
             },
             options: {
                 select: ['web-tls']

--- a/test/good.js
+++ b/test/good.js
@@ -9,10 +9,14 @@ const Path = require('path');
 const Config = require('../lib/config');
 const Good = require('../lib/good');
 const GoodPlugin = require('good');
+const Hoek = require('hoek');
+const Fs = require('fs');
 
 // Declare internals
 
 const internals = {};
+
+internals.goodFilePath = './test/fixtures/awesomeLog.json';
 
 // Test shortcuts
 
@@ -20,8 +24,18 @@ const lab = exports.lab = Lab.script();
 const describe = lab.experiment;
 const expect = Code.expect;
 const it = lab.test;
+const beforeEach = lab.beforeEach;
 
 describe('/good', () => {
+
+    // Leave log file around till next test run for manual inspection
+    beforeEach(done => {
+        Fs.truncate(internals.goodFilePath, (err) => {
+
+            Hoek.assert(!err, 'There was an error cleaning up the test log file. In order for future tests to pass, ensure you delete '+internals.goodFilePath);
+            done();
+        });
+    });
 
     it('errors on failed registering good registration plugin', { parallel: false }, (done) => {
 
@@ -73,7 +87,52 @@ describe('/good', () => {
             done();
         });
     });
-    return;
+
+    it('options should be correctly passed through to good itself when registering our `good registration plugin`', { parallel: false }, (done) => {
+
+        University.init(internals.manifest, internals.composeOptions, (err, server) => {
+
+            expect(err).to.not.exist();
+
+            // select each connection
+            const web = server.select('web');
+            const webTls = server.select('web-tls');
+
+            // log these to connection web
+            const actualWebLogMsg = 'A: ' + web.info.uri;
+            const actualWebLogTags = ['my-web-tag', 'another-tag'];
+            server.log(actualWebLogTags, actualWebLogMsg);
+            // Expect this is found from logging on previous line
+            const expectedWebDataPart = 'A: http';
+
+            // rinse/repeat for webTls connection
+            const actualWebTlsLogMsg = 'B: ' + webTls.info.uri;
+            const actualWebTlsLogTags = ['my-web-tls-tag', 'fourth-tag'];
+            server.log(actualWebTlsLogTags, actualWebTlsLogMsg);
+            const expectedWebTlsDataPart = 'B: https';
+
+            // Single event is coalesced from the 2 we fired b/c we did them in same event loop turn
+            server.on('log', (/*event, tags*/) => {
+                Fs.readFile(internals.goodFilePath, { encoding: 'utf8' }, (err, contents) => {
+
+                    expect(err).to.not.exist();
+
+                    const lines = contents.trim().split('\n');
+
+                    const webLogJson = JSON.parse(lines[0]);
+                    const webTlsLogJson = JSON.parse(lines[1]);
+
+                    expect(webLogJson.data).to.include(expectedWebDataPart);
+                    expect(webLogJson.tags).to.equal(actualWebLogTags);
+
+                    expect(webTlsLogJson.data).to.include(expectedWebTlsDataPart);
+                    expect(webTlsLogJson.tags).to.equal(actualWebTlsLogTags);
+
+                    done();
+                });
+            });
+        });
+    });
 });
 
 internals.manifest = {
@@ -92,9 +151,25 @@ internals.manifest = {
     ],
     registrations: [
         {
-            plugin: './good',
-            options: {
-                select: ['web-tls']
+            plugin: {
+                register: './good',
+                options: {
+                    ops: { interval: 1000 },
+                    reporters: {
+                        myFileReporter: [{
+                            module: 'good-squeeze',
+                            name: 'Squeeze',
+                            args: [{ log: '*', }] // Required for `server.log`. There are many log events that are important, check out the good docs for more :)
+                        }, {
+                            module: 'good-squeeze',
+                            name: 'SafeJson'
+                        }, {
+                            module: 'good-file',
+                            args: [internals.goodFilePath]
+                        }]
+                    }
+
+                }
             }
         }
     ]

--- a/test/good.js
+++ b/test/good.js
@@ -29,10 +29,11 @@ const beforeEach = lab.beforeEach;
 describe('/good', () => {
 
     // Leave log file around till next test run for manual inspection
-    beforeEach(done => {
+    beforeEach((done) => {
+
         Fs.truncate(internals.goodFilePath, (err) => {
 
-            Hoek.assert(!err, 'There was an error cleaning up the test log file. In order for future tests to pass, ensure you delete '+internals.goodFilePath);
+            Hoek.assert(!err, 'There was an error cleaning up the test log file. In order for future tests to pass, ensure you delete ' + internals.goodFilePath);
             done();
         });
     });
@@ -113,6 +114,7 @@ describe('/good', () => {
 
             // Single event is coalesced from the 2 we fired b/c we did them in same event loop turn
             server.on('log', (/*event, tags*/) => {
+
                 Fs.readFile(internals.goodFilePath, { encoding: 'utf8' }, (err, contents) => {
 
                     expect(err).to.not.exist();
@@ -159,7 +161,7 @@ internals.manifest = {
                         myFileReporter: [{
                             module: 'good-squeeze',
                             name: 'Squeeze',
-                            args: [{ log: '*', }] // Required for `server.log`. There are many log events that are important, check out the good docs for more :)
+                            args: [{ log: '*' }] // Required for `server.log`. There are many log events that are important, check out the good docs for more :)
                         }, {
                             module: 'good-squeeze',
                             name: 'SafeJson'

--- a/test/good.js
+++ b/test/good.js
@@ -24,19 +24,9 @@ const lab = exports.lab = Lab.script();
 const describe = lab.experiment;
 const expect = Code.expect;
 const it = lab.test;
-const beforeEach = lab.beforeEach;
+const afterEach = lab.afterEach;
 
 describe('/good', () => {
-
-    // Leave log file around till next test run for manual inspection
-    beforeEach((done) => {
-
-        Fs.truncate(internals.goodFilePath, (err) => {
-
-            Hoek.assert(!err, 'There was an error cleaning up the test log file. In order for future tests to pass, ensure you delete ' + internals.goodFilePath);
-            done();
-        });
-    });
 
     it('errors on failed registering good registration plugin', { parallel: false }, (done) => {
 
@@ -85,6 +75,19 @@ describe('/good', () => {
         University.init(internals.manifest, internals.composeOptions, (err) => {
 
             expect(err).to.not.exist();
+            done();
+        });
+    });
+});
+
+describe('/good integration', () => {
+
+    // We use a seperate describe block so we can ensure we cleanup as this test creates a real log file
+    afterEach((done) => {
+
+        Fs.truncate(internals.goodFilePath, (err) => {
+
+            Hoek.assert(!err, err);
             done();
         });
     });

--- a/test/home.js
+++ b/test/home.js
@@ -415,11 +415,14 @@ internals.manifest = {
             plugin: 'hapi-auth-cookie'
         },
         {
-            plugin: './crumbit',
+            plugin: {
+                register: './crumbit',
+                options: Config.crumbOptions,
+            },
             options: {
                 select: ['web-tls']
             }
-        }
+        },
     ]
 };
 

--- a/test/home.js
+++ b/test/home.js
@@ -417,12 +417,12 @@ internals.manifest = {
         {
             plugin: {
                 register: './crumbit',
-                options: Config.crumbOptions,
+                options: Config.crumbOptions
             },
             options: {
                 select: ['web-tls']
             }
-        },
+        }
     ]
 };
 


### PR DESCRIPTION
Refine and clarify code having to do with use of glue, testing and logging

This PR contains more than one concern. It is also based off of assignment 8. It may therefore not be something to merge as is. If there is interest in one or more parts, I don't mind picking this apart according to feedback. Fyi.

Loose Notes:

- Upon initially learning Hapi earlier this year there we're some
  things that led me to eventually remove Glue from my app. This later made
  testing difficult. Coming back to this repo led me to see what confused
  me - which mainly revolved around pluginOptions vs registerOptions. Glue
  uses the registerOptions while pluginOptions can be passed to a plugin 
  from the main app. This is especially useful when working with connectionless
  plugins.

- Along the way I also saw some patterns dealing with the log events + use
  of good that helped me look at my own app logging situation a bit differently.

- I also noted the use of small things like using process.cwd() over `__dirname`
  that I found useful in my own server when working with babel/typescript +
  rollup. 

As I saw such things I made an attempt to clarify them. The changes are all
benign meaning there is no new functionality, just code re-organization.

Feel free to use what seems useful or the whole branch in further
assignments/refactors.

Thanks for the awesome example btw. Without it I would never starting 
using Hapi all those months ago.  